### PR TITLE
Use Metabase image built for M1

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@
 ### SHARED ###
 VERSION=0.35.5-alpha
 AIRBYTE_IMAGE_PREFIX="airbyte/"
+METABASE_IMAGE="metabase/metabase"
 
 # When using the airbyte-db via default docker image
 CONFIG_ROOT=/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,8 @@ services:
   metabase:
     build:
       context: ./metabase
+      args:
+        - METABASE_IMAGE=${METABASE_IMAGE}
     container_name: metabase
     ports:
       - ${METABASE_PORT?}:3000

--- a/metabase/Dockerfile
+++ b/metabase/Dockerfile
@@ -1,4 +1,5 @@
-FROM metabase/metabase:v0.41.6
+ARG METABASE_IMAGE
+FROM ${METABASE_IMAGE}:v0.41.6
 RUN mkdir /faros
 COPY log4j2.xml /faros/
 ENV JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.formatMsgNoLookups=true -Dlog4j.configurationFile=file:/faros/log4j2.xml"

--- a/start.sh
+++ b/start.sh
@@ -25,8 +25,8 @@ fi
 export FAROS_EMAIL=$EMAIL
 
 if [[ `uname -m 2> /dev/null` == 'arm64' ]]; then
-    # Use Airbyte images built for Apple M1
-    AIRBYTE_IMAGE_PREFIX="farosai/airbyte-" docker-compose up --build --remove-orphans
+    # Use Airbyte and Metabase images built for Apple M1
+    AIRBYTE_IMAGE_PREFIX="farosai/airbyte-" METABASE_IMAGE="farosai/metabase-m1" docker-compose up --build --remove-orphans
 else
     docker-compose up --build --remove-orphans
 fi


### PR DESCRIPTION
Use Metabase image built for M1 (from the Faros docker repo) if we detect we're running in M1.