### PR TITLE
Remove list for type of change in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,14 +5,14 @@ Please include a summary of the change and which issue is fixed. Please also inc
 Fixes # (issue)
 
 ## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+(Delete what does not apply)
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
 
 # Checklist
-
+(Delete what does not apply)
 - [ ] Have you checked to there aren't other open Pull Requests for the same update/change?
 - [ ] Have you lint your code locally before submission?
 - [ ] Have you added an explanation of what your changes do and why you'd like us to include them?


### PR DESCRIPTION
To avoid them being treated as tasks by GitHub

