### PR TITLE
Hasura to accept database url

### DIFF
--- a/init/src/hasura/init.ts
+++ b/init/src/hasura/init.ts
@@ -242,9 +242,9 @@ export class HasuraInit {
       configuration: {
         connection_info: {
           use_prepared_statements: true,
-          database_url: databaseUrl ? databaseUrl : {
-            from_env: 'HASURA_GRAPHQL_DATABASE_URL',
-          },
+          database_url: databaseUrl || {
+                from_env: 'HASURA_GRAPHQL_DATABASE_URL',
+              },
           isolation_level: 'read-committed',
           pool_settings: {
             connection_lifetime: 600,
@@ -414,7 +414,13 @@ export class HasuraInit {
     if (trackedTables.length === 0) {
       await this.loadMetadata({
         version: 3,
-        sources: [HasuraInit.createSourceMetadata(allTableNames, foreignKeys, databaseUrl)],
+        sources: [
+          HasuraInit.createSourceMetadata(
+            allTableNames,
+            foreignKeys,
+            databaseUrl
+          ),
+        ],
       });
       this.logger.info('Loaded source metadata into Hasura');
       return;

--- a/init/src/hasura/init.ts
+++ b/init/src/hasura/init.ts
@@ -200,7 +200,8 @@ export class HasuraInit {
 
   static createSourceMetadata(
     tableNames: ReadonlyArray<string>,
-    foreignKeys: ReadonlyArray<ForeignKey>
+    foreignKeys: ReadonlyArray<ForeignKey>,
+    databaseUrl?: string
   ): Source {
     const rels: {
       [table: string]: {
@@ -241,7 +242,7 @@ export class HasuraInit {
       configuration: {
         connection_info: {
           use_prepared_statements: true,
-          database_url: {
+          database_url: databaseUrl ? databaseUrl : {
             from_env: 'HASURA_GRAPHQL_DATABASE_URL',
           },
           isolation_level: 'read-committed',
@@ -402,7 +403,7 @@ export class HasuraInit {
     await this.updateEndpoints(queryCollectionFromResources);
   }
 
-  async trackAllTablesAndRelationships(): Promise<void> {
+  async trackAllTablesAndRelationships(databaseUrl?: string): Promise<void> {
     const allTableNames = await this.listAllTables();
     const source = await this.getDbSource();
     const foreignKeys = await this.listAllForeignKeys();
@@ -410,11 +411,10 @@ export class HasuraInit {
     const trackedTables = source.tables.filter(
       (table) => table.table.schema === 'public'
     );
-
     if (trackedTables.length === 0) {
       await this.loadMetadata({
         version: 3,
-        sources: [HasuraInit.createSourceMetadata(allTableNames, foreignKeys)],
+        sources: [HasuraInit.createSourceMetadata(allTableNames, foreignKeys, databaseUrl)],
       });
       this.logger.info('Loaded source metadata into Hasura');
       return;
@@ -480,7 +480,8 @@ export class HasuraInit {
 async function main(): Promise<void> {
   program
     .requiredOption('--hasura-url <string>')
-    .option('--admin-secret <string>');
+    .option('--admin-secret <string>')
+    .option('--database-url <string>');
 
   program.parse();
   const options = program.opts();
@@ -503,7 +504,7 @@ async function main(): Promise<void> {
     logger
   );
 
-  await hasura.trackAllTablesAndRelationships();
+  await hasura.trackAllTablesAndRelationships(options.databaseUrl);
   await hasura.createEndpoints();
 
   logger.info('Hasura setup is complete');


### PR DESCRIPTION
# Description

Accepts a db url pointing to the hasura data database to use (i.e., equivalent to the `HASURA_GRAPHQL_DATABASE_URL` env var provided during deployment of hasura). This is useful to switch the underlying data database for Hasura after Hasura has been deployed.

Fixes # (issue)

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
