### PR TITLE
Fixes loading of Hasura metadata

### DIFF
--- a/init/src/hasura/init.ts
+++ b/init/src/hasura/init.ts
@@ -422,6 +422,22 @@ export class HasuraInit {
           ),
         ],
       });
+
+      if (allTableNames.length === 0 && databaseUrl) {
+        const tableNamesFromDbUrl = await this.listAllTables();
+        const foreignKeysFromDbUrl = await this.listAllForeignKeys();
+        await this.loadMetadata({
+          version: 3,
+          sources: [
+            HasuraInit.createSourceMetadata(
+              tableNamesFromDbUrl,
+              foreignKeysFromDbUrl,
+              databaseUrl
+            ),
+          ],
+        });
+      }
+
       this.logger.info('Loaded source metadata into Hasura');
       return;
     }


### PR DESCRIPTION
# Description

This change fixes the loading of the Hasura metadata for the case where a database url is specified via the `database-url` of the init script. When the database specified via the parameter is not the same as the one Hasura was deployed with (i.e., the one from the `HASURA_GRAPHQL_DATABASE_URL` env var), the init script will not find any table names or foreign keys in the first pass, so we first load the metadata so that the source is updated and then ask for table names and foreign keys again, then update the metadata one more time, this time with table names and foreign keys so that they are tracked.

Fixes # (issue)

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# Checklist
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
