### PR TITLE
Wait for Faros DB and Hasura/Metabase/n8n databases to exist before attempting to bring up other services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,7 +75,11 @@ services:
       METABASE_DB_NAME: ${METABASE_DB_NAME?}
       N8N_DB_NAME: ${N8N_DB_NAME?}
     healthcheck:
-      test: ["CMD", "psql", "-d", "postgres://${FAROS_DB_USER?}:${FAROS_DB_PASSWORD?}@${FAROS_DB_HOST?}:${FAROS_DB_PORT?}/${FAROS_DB_NAME?}", "-c", "SELECT 1"]
+      test: ["CMD", "psql", "-d", "postgres://${FAROS_CONFIG_DB_USER?}:${FAROS_CONFIG_DB_PASSWORD?}@${FAROS_CONFIG_DB_HOST?}:${FAROS_CONFIG_DB_PORT?}/${N8N_DB_NAME?}", "-c", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      start_period: 1m
+      retries: 5
   hasura:
     profiles: ["default"]
     image: hasura/graphql-engine:${HASURA_VERSION?}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,6 +74,8 @@ services:
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET?}
       METABASE_DB_NAME: ${METABASE_DB_NAME?}
       N8N_DB_NAME: ${N8N_DB_NAME?}
+    healthcheck:
+      test: ["CMD", "psql", "-d", "postgres://${FAROS_DB_USER?}:${FAROS_DB_PASSWORD?}@${FAROS_DB_HOST?}:${FAROS_DB_PORT?}/${FAROS_DB_NAME?}", "-c", "SELECT 1"]
   hasura:
     profiles: ["default"]
     image: hasura/graphql-engine:${HASURA_VERSION?}
@@ -81,7 +83,8 @@ services:
     ports:
       - ${HASURA_PORT?}:8080
     depends_on:
-      - faros-init
+      faros-init:
+          condition: service_healthy
     restart: unless-stopped
     environment:
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET?}
@@ -101,7 +104,8 @@ services:
     ports:
       - ${METABASE_PORT?}:3000
     depends_on:
-      - faros-init
+      faros-init:
+          condition: service_healthy
     restart: unless-stopped
     environment:
       MB_ANON_TRACKING_ENABLED: "false"
@@ -121,7 +125,8 @@ services:
     ports:
       - ${N8N_PORT?}:5678
     depends_on:
-      - faros-init
+      faros-init:
+          condition: service_healthy
     restart: unless-stopped
     environment:
       DB_TYPE: postgresdb

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,9 +76,9 @@ services:
       N8N_DB_NAME: ${N8N_DB_NAME?}
     healthcheck:
       test: ["CMD", "psql", "-d", "postgres://${FAROS_CONFIG_DB_USER?}:${FAROS_CONFIG_DB_PASSWORD?}@${FAROS_CONFIG_DB_HOST?}:${FAROS_CONFIG_DB_PORT?}/${N8N_DB_NAME?}", "-c", "SELECT 1"]
-      interval: 10s
+      interval: 15s
       timeout: 5s
-      start_period: 1m
+      start_period: 30s
       retries: 5
   hasura:
     profiles: ["default"]


### PR DESCRIPTION
# Description

This change blocks Docker compose from attempting to bring up Hasura/Metabase/n8n until faros-init has created all the databases (Faros DB, Hasura/Metabase/n8n cfg databases). At the moment, we see a lot of failures/retries because these services attempt to connect to the database before it is available.

The issue has been reported here: https://faroscommunity.slack.com/archives/C0335HMN2NQ/p1648851029917679

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [ ] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully run tests with your changes locally?
