### PR TITLE
Move unit tests into its own directory

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,15 +38,15 @@ jobs:
         run: npm ci --unsafe-perm
         working-directory: init
 
+      - name: Run unit tests
+        run: npm run test:unit -- --coverage
+        working-directory: init
+
       - name: Docker Compose version
         run: docker-compose version --short
 
       - name: Start services
         run: docker-compose up --quiet-pull -d
-
-      - name: Run tests
-        run: npm test -- --coverage
-        working-directory: init
 
       - name: Show logs
         run: docker-compose logs --tail all

--- a/init/package.json
+++ b/init/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepare": "npm run build",
     "test": "jest --verbose --color",
+    "test:unit": "jest test/unit-tests/**/*.ts --verbose --color",
     "test-cov": "jest --coverage --verbose --color",
     "watch": "tsc -b -w src test"
   },

--- a/init/test/unit-tests/airbyte/init.test.ts
+++ b/init/test/unit-tests/airbyte/init.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import {AirbyteInit, FAROS_DEST_REPO} from '../../src/airbyte/init';
+import {AirbyteInit, FAROS_DEST_REPO} from '../../../src/airbyte/init';
 
 describe('airbyte', () => {
   test('get latest Faros Destination version', async () => {

--- a/init/test/unit-tests/hasura/init.test.ts
+++ b/init/test/unit-tests/hasura/init.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 import path from 'path';
 import pino from 'pino';
 
-import {HasuraInit} from '../../src/hasura/init';
+import {HasuraInit} from '../../../src/hasura/init';
 import {
   addCollectionToAllowlist,
   addEndpoint,
@@ -36,7 +36,7 @@ describe('init', () => {
       headers: {'X-Hasura-Role': 'admin'},
     }),
     logger,
-    path.join(__dirname, '..', 'resources', 'hasura')
+    path.join(__dirname, '..', '..', 'resources', 'hasura')
   );
 
   beforeEach(() => {

--- a/init/test/unit-tests/hasura/testing-helpers.ts
+++ b/init/test/unit-tests/hasura/testing-helpers.ts
@@ -1,4 +1,4 @@
-import {Endpoint, QueryCollection} from '../../src/hasura/types';
+import {Endpoint, QueryCollection} from '../../../src/hasura/types';
 
 export function getMetadata() {
   return {


### PR DESCRIPTION
# Description

In preparation for adding integration tests, moves unit tests into its own directory.
Updates the scripts so that `npm test` runs all tests, `npm run test:unit` runs only the unit tests (and a future `npm run test:integration` will run only integration tests)
Also, moves the unit tests execution in the GHA to before the Docker related steps, so that GHA can fail faster if there are unit tests failures.

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
