### PR TITLE
Increase test timeout to 10 mins

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Check out


### PR DESCRIPTION
# Description

It takes some time to spool up the services & initialize them prior to tests. Increasing the timeout from 5  to 10 minutes. 

Fixes - https://github.com/faros-ai/faros-community-edition/actions/runs/2150863704

## Type of change
- New feature (non-breaking change which adds functionality)

