### PR TITLE
Adds option to trigger db sync in metabase init script

### DIFF
--- a/init/src/metabase/dashboards.ts
+++ b/init/src/metabase/dashboards.ts
@@ -456,9 +456,9 @@ export class Dashboards {
         JSON.parse(handlebars.compile(template)({})),
         (key, value) => {
           return key === 'query' && isString(value)
-            // ->> and #>> must not be replaced
-            // https://www.postgresql.org/docs/9.4/functions-json.html
-            ? value.replace(/<</g, '{{').replace(/([^-#])>>/g, '$1}}')
+            ? // ->> and #>> must not be replaced
+              // https://www.postgresql.org/docs/9.4/functions-json.html
+              value.replace(/<</g, '{{').replace(/([^-#])>>/g, '$1}}')
             : value;
         }
       )

--- a/init/src/metabase/dashboards.ts
+++ b/init/src/metabase/dashboards.ts
@@ -455,10 +455,10 @@ export class Dashboards {
       JSON.stringify(
         JSON.parse(handlebars.compile(template)({})),
         (key, value) => {
+          // ->> and #>> must not be replaced
+          // https://www.postgresql.org/docs/9.4/functions-json.html
           return key === 'query' && isString(value)
-            ? // ->> and #>> must not be replaced
-              // https://www.postgresql.org/docs/9.4/functions-json.html
-              value.replace(/<</g, '{{').replace(/([^-#])>>/g, '$1}}')
+            ? value.replace(/<</g, '{{').replace(/([^-#])>>/g, '$1}}')
             : value;
         }
       )

--- a/init/src/metabase/init.ts
+++ b/init/src/metabase/init.ts
@@ -48,6 +48,7 @@ async function main(): Promise<void> {
 
     if (options.export) {
       console.log(await dashboards.export(parseInt(options.export, 10)));
+      logger.info('Metabase export is complete');
     } else {
       await dashboards.import();
       logger.info('Metabase import is complete');

--- a/init/src/metabase/metabase.ts
+++ b/init/src/metabase/metabase.ts
@@ -73,6 +73,16 @@ export class Metabase {
     }
   }
 
+  async syncSchema(databaseName: string): Promise<void> {
+    const db = await this.getDatabase(databaseName);
+
+    if (!db) {
+      throw new VError('unable to find database: ' + databaseName);
+    }
+
+    await this.api.post(`database/${db.id}/sync_schema`);
+  }
+
   async syncTables(
     schema: string,
     fieldsByTable: Map<string, Set<string>>,


### PR DESCRIPTION
# Description

Adds option to trigger db sync in metabase init script. This is so that new tables (e.g., created via dbt) can be picked up after the initial setup.

Also, shows the script help when no operation is specified.

## Type of change
(Delete what does not apply)
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
