### PR TITLE
Ignore table_id on card equality

### DIFF
--- a/init/src/metabase/dashboards.ts
+++ b/init/src/metabase/dashboards.ts
@@ -672,7 +672,9 @@ export class Dashboards {
   }
 
   private static equalCards(card1: any, card2: any): boolean {
-    const predicate = (v: any, k: string): boolean => k === 'id' || !v;
+    // series cards lack a table_id on export
+    const predicate = (v: any, k: string): boolean =>
+      k === 'id' || k === 'table_id' || !v;
     return isEqual(omitBy(card1, predicate), omitBy(card2, predicate));
   }
 }


### PR DESCRIPTION
# Description

Series cards lack table_id when loaded from the dashboard API call. To avoid overwriting identical cards on dashboard import, we ignore table_id on card equality.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
