### PR TITLE
Adds integration tests for Hasura endpoints

### DIFF
--- a/init/test/integration-tests/hasura-client.ts
+++ b/init/test/integration-tests/hasura-client.ts
@@ -41,6 +41,27 @@ export class HasuraClient {
     );
   }
 
+  async hitEndpoint(endpoint: string, payload: string): Promise<any> {
+    return await this.api
+      .post(`/api/rest/${endpoint}`, payload)
+      .then((response) => response.data)
+      .catch((err) => {
+        logger.info(`query failed with error: ${err}`);
+      });
+  }
+
+  async makeQuery(query: string): Promise<any> {
+    return await this.api
+      .post('/v1/graphql', {
+        query,
+        variables: null,
+      })
+      .then((response) => response.data)
+      .catch((err) => {
+        logger.info(`query failed with error: ${err}`);
+      });
+  }
+
   async getVcsUserCount(): Promise<number> {
     return await this.api
       .post('/v1/graphql', {

--- a/init/test/integration-tests/types.ts
+++ b/init/test/integration-tests/types.ts
@@ -1,0 +1,6 @@
+export interface TestDefinition {
+  endpoint: string;
+  input: string;
+  output: string;
+  query: string;
+}

--- a/init/test/resources/hasura/test_data/cicd_organization.gql
+++ b/init/test/resources/hasura/test_data/cicd_organization.gql
@@ -1,0 +1,12 @@
+query MyQuery {
+  cicd_Organization(where: {origin: {_eq: "origin1"}}) {
+    description
+    id
+    name
+    origin
+    # refreshedAt
+    source
+    uid
+    url
+  }
+}

--- a/init/test/resources/hasura/test_data/cicd_organization_in.json
+++ b/init/test/resources/hasura/test_data/cicd_organization_in.json
@@ -1,0 +1,5 @@
+{
+  "data_origin": "origin1",
+  "data_artifact_organization": "organization1",
+  "data_artifact_source": "source1"
+}

--- a/init/test/resources/hasura/test_data/cicd_organization_out.json
+++ b/init/test/resources/hasura/test_data/cicd_organization_out.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "cicd_Organization": [
+      {
+        "description": null,
+        "id": "source1|organization1",
+        "name": null,
+        "origin": "origin1",
+        "source": "source1",
+        "uid": "organization1",
+        "url": null
+      }
+    ]
+  }
+}

--- a/init/test/resources/hasura/test_definitions/cicd_organization.json
+++ b/init/test/resources/hasura/test_definitions/cicd_organization.json
@@ -1,0 +1,6 @@
+{
+  "endpoint": "cicd_organization",
+  "input": "cicd_organization_in.json",
+  "output": "cicd_organization_out.json",
+  "query": "cicd_organization.gql"
+}


### PR DESCRIPTION
# Description

Adds the ability to test the Hasura mutation endpoints by including:

- a json file with the input (payload) with which to hit the endpoint under test
- a Hasura query to fetch the actual data that was written into the table
- a json file with the expected data to compare
- a test definition file pointing to the files above and specifying the endpoint name

I'll add tests for the remaining endpoints after merging this PR.

## Type of change
(Delete what does not apply)
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
