### PR TITLE
Make the init container fail on any initialization failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,8 @@ services:
   faros-init:
     profiles: ["default", "faros-init"]
     image: ${FAROS_INIT_IMAGE?}
-    restart: on-failure
+    # 3 retries on failure
+    restart: on-failure:3
     environment:
       AIRBYTE_API_CALLS_CONCURRENCY: ${AIRBYTE_API_CALLS_CONCURRENCY:-}
       AIRBYTE_DESTINATION_HASURA_URL: ${AIRBYTE_DESTINATION_HASURA_URL?}

--- a/init/scripts/db-init.sh
+++ b/init/scripts/db-init.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -eo pipefail
 
 faros_db_name=${FAROS_DB_NAME}
 faros_db_host=${FAROS_DB_HOST}

--- a/init/scripts/metabase-init.sh
+++ b/init/scripts/metabase-init.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 [[ -z "$METABASE_URL" ]] && echo "METABASE_URL not set" && exit 1
 [[ -z "$METABASE_USER" ]] && echo "METABASE_USER not set" && exit 1
 [[ -z "$METABASE_PASSWORD" ]] && echo "METABASE_PASSWORD not set" && exit 1


### PR DESCRIPTION
# Description

Make the init container fail on any initialization failure.

Scenarios verified:

- Unreachable db, Airbyte, Hasura or Metabase webapps.
- Error in Flyway migration (typo in a table name in a foreign key reference).
- Error in Airbyte/Hasura/Metabase initialization scripts (I added a `throw` to the top of `main`)

Fixes #159 (I verified that `docker-compose up` exit code is 1 in my local. I expect the GHA to fail and hence stop the release)

## Type of change
(Delete what does not apply)
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
