### PR TITLE
Actually fail workflow if init fails

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Wait for init to complete
         run: |
-          [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
+          CONTAINER_EXIT_CODE=$(docker wait faros-community-edition_faros-init_1)
+          echo "init exit code was ${CONTAINER_EXIT_CODE}"
+          [[ $CONTAINER_EXIT_CODE -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
         run: docker-compose ps -a
 
       - name: Wait for init to complete
-        run: docker wait faros-community-edition_faros-init_1
+        run: [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Wait for init to complete
         run: |
           CONTAINER_EXIT_CODE=$(docker wait faros-community-edition_faros-init_1)
-          echo "init exit code was ${CONTAINER_EXIT_CODE}"
+          echo "Faros init container exit code was ${CONTAINER_EXIT_CODE}"
           [[ $CONTAINER_EXIT_CODE -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,8 @@ jobs:
         run: docker-compose ps -a
 
       - name: Wait for init to complete
-        run: [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
+        run: |
+          [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,9 @@ jobs:
 
       - name: Wait for init to complete
         run: |
-          [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
+          CONTAINER_EXIT_CODE=$(docker wait faros-community-edition_faros-init_1)
+          echo "init exit code was ${CONTAINER_EXIT_CODE}"
+          [[ $CONTAINER_EXIT_CODE -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: docker-compose ps -a
 
       - name: Wait for init to complete
-        run: docker wait faros-community-edition_faros-init_1
+        run: [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
         run: docker-compose ps -a
 
       - name: Wait for init to complete
-        run: [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
+        run: |
+          [[ $(docker wait faros-community-edition_faros-init_1) -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Wait for init to complete
         run: |
           CONTAINER_EXIT_CODE=$(docker wait faros-community-edition_faros-init_1)
-          echo "init exit code was ${CONTAINER_EXIT_CODE}"
+          echo "Faros init container exit code was ${CONTAINER_EXIT_CODE}"
           [[ $CONTAINER_EXIT_CODE -eq 0 ]]
 
       - name: Get destination id & Hasura Admin Secret


### PR DESCRIPTION
# Description

`docker wait <container>` does NOT exit with the container exit code. Instead, it prints out the container exit code.
Before this change, even if the Faros init container fails, it won't stop the GHA workflows.

We capture the container exit code from the output and fail if non-zero.

## Type of change
(Delete what does not apply)
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
