### PR TITLE
Fix options conflicts in Metabase init script

### DIFF
--- a/init/src/hasura/init.ts
+++ b/init/src/hasura/init.ts
@@ -322,7 +322,7 @@ export class HasuraInit {
       // The query collection from resources doesn't exist in the metadata.
       // Safely create a new query collection.
       this.logger.info(
-        'Creating query collection \'%s\'. %d queries added',
+        "Creating query collection '%s'. %d queries added",
         queryCollectionFromResources.name,
         queryCollectionFromResources.definition.queries.length
       );
@@ -350,7 +350,7 @@ export class HasuraInit {
 
       if (toAdd.length > 0) {
         this.logger.info(
-          'Updating query collection \'%s\'. %d queries added.',
+          "Updating query collection '%s'. %d queries added.",
           queryCollectionFromResources.name,
           toAdd.length
         );

--- a/init/src/metabase/init.ts
+++ b/init/src/metabase/init.ts
@@ -17,16 +17,16 @@ async function main(): Promise<void> {
     .requiredOption('--database <string>')
     .addOption(
       new Option('--export <dashboardId>')
-        .conflicts('import-one')
-        .conflicts('import-new')
+        .conflicts('importOne')
+        .conflicts('importNew')
     )
     .addOption(
       new Option('--import-one <filename>')
         .conflicts('export')
-        .conflicts('import-new')
+        .conflicts('importNew')
     )
     .addOption(
-      new Option('--import-new').conflicts('export').conflicts('import-one')
+      new Option('--import-new').conflicts('export').conflicts('importOne')
     )
     .addOption(new Option('--sync-schema'));
 


### PR DESCRIPTION
# Description

The options in `conflicts` should be specified in camel case.
This is unfortunately not documented in the [commander docs](https://www.npmjs.com/package/commander#options) where there are no examples of options with compound words.

No other scripts are affected in this repo.

## Type of change
(Delete what does not apply)
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
