### PR TITLE
Remove default 30 days filter on most build charts

### DIFF
--- a/init/resources/metabase/dashboards/builds.json
+++ b/init/resources/metabase/dashboards/builds.json
@@ -14,16 +14,6 @@
               "count"
             ]
           ],
-          "filter": [
-            "time-interval",
-            [
-              "field",
-              {{ field "cicd_Build.createdAt" }},
-              null
-            ],
-            -30,
-            "day"
-          ],
           "breakout": [
             [
               "field",
@@ -189,26 +179,13 @@
         "query": {
           "source-table": {{ table "cicd_Build" }},
           "filter": [
-            "and",
+            "!=",
             [
-              "!=",
-              [
-                "field",
-                {{ field "cicd_Build.statusCategory" }},
-                null
-              ],
-              "Success"
+              "field",
+              {{ field "cicd_Build.statusCategory" }},
+              null
             ],
-            [
-              "time-interval",
-              [
-                "field",
-                {{ field "cicd_Build.createdAt" }},
-                null
-              ],
-              -30,
-              "day"
-            ]
+            "Success" 
           ],
           "breakout": [
             [

--- a/init/resources/metabase/dashboards/builds.json
+++ b/init/resources/metabase/dashboards/builds.json
@@ -101,8 +101,7 @@
                 {{ field "cicd_Build.createdAt" }},
                 null
               ],
-              "widget-type": "date/relative",
-              "default": "past30days"
+              "widget-type": "date/relative"
             },
             "pipelineName": {
               "id": "5ba685b5-d77e-1aec-e1af-2d9785f02791",
@@ -147,8 +146,7 @@
                 {{ field "cicd_Build.createdAt" }},
                 null
               ],
-              "widget-type": "date/relative",
-              "default": "past30days"
+              "widget-type": "date/relative"
             },
             "pipelineName": {
               "id": "5ba685b5-d77e-1aec-e1af-2d9785f02791",
@@ -271,8 +269,7 @@
                 {{ field "cicd_Build.createdAt" }},
                 null
               ],
-              "widget-type": "date/relative",
-              "default": "past30days"
+              "widget-type": "date/relative"
             },
             "pipelineName": {
               "id": "9b68bcc7-1834-3002-2ec6-8a2f55fc0883",
@@ -321,8 +318,7 @@
                 {{ field "cicd_Build.createdAt" }},
                 null
               ],
-              "widget-type": "date/relative",
-              "default": "past30days"
+              "widget-type": "date/relative"
             }
           },
           "query": "SELECT avg(\"source\".\"count\") AS \"avg\"\nFROM (SELECT (CAST(date_trunc('week', CAST((CAST(\"cicd_Build\".\"createdAt\" AS timestamp) + (INTERVAL '1 day')) AS timestamp)) AS timestamp) + (INTERVAL '-1 day')) AS \"createdAt\", count(*) AS \"count\" FROM \"cicd_Build\"\nLEFT JOIN \"cicd_Pipeline\" ON \"cicd_Build\".\"pipeline\" = \"cicd_Pipeline\".\"id\"\nWHERE <<pipelineName>> AND <<createdAt>>\nGROUP BY (CAST(date_trunc('week', CAST((CAST(\"public\".\"cicd_Build\".\"createdAt\" AS timestamp) + (INTERVAL '1 day')) AS timestamp)) AS timestamp) + (INTERVAL '-1 day'))\nORDER BY (CAST(date_trunc('week', CAST((CAST(\"public\".\"cicd_Build\".\"createdAt\" AS timestamp) + (INTERVAL '1 day')) AS timestamp)) AS timestamp) + (INTERVAL '-1 day')) ASC) \"source\""


### PR DESCRIPTION
# Description

All SQL questions on the build canned dashboard have a 30 days default set, which prevents the dashboard from seeing more than the last 30 days.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
