### PR TITLE
Updates Airbyte GitLab community source on start

### DIFF
--- a/init/src/airbyte/init.ts
+++ b/init/src/airbyte/init.ts
@@ -239,7 +239,8 @@ export class AirbyteInit {
     ).filter(
       (sd) =>
         sd.dockerRepository.startsWith('farosai/') ||
-        sd.dockerRepository === 'airbyte/source-jira'
+        sd.dockerRepository === 'airbyte/source-jira' ||
+        sd.dockerRepository === 'airbyte/source-gitlab'
     );
 
     const promises: Promise<void>[] = [];


### PR DESCRIPTION
# Description

Since we pre-configure the community GitLab source, we autoupdate it on start.
Similar to what we do for any pre-configured sources, whether it is the community Jira or all our connectors.

Note that we got somewhat saved so far by the [airbyte bootstrap process](https://github.com/faros-ai/faros-community-edition/blob/main/.env#L165) that updates certain connectors for compatibility reasons.

## Type of change
(Delete what does not apply)
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
