### PR TITLE
Add back pull of latest init image

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -48,6 +48,7 @@ main() {
 
   # Ensure we're using the latest faros-init image
   export FAROS_INIT_IMAGE=farosai.docker.scarf.sh/farosai/faros-ce-init:latest
+  docker compose pull faros-init
 
   if [[ $(uname -m 2> /dev/null) == 'arm64' ]]; then
       # Use Metabase images built for Apple M1


### PR DESCRIPTION
# Description

Adds back command so that the latest Faros init image is pulled

Fixes # (issue)

## Type of change
(Delete what does not apply)
- Bug fix (non-breaking change which fixes an issue)



