### PR TITLE
Email arg in start script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,5 +2,4 @@
 
 git clone https://github.com/faros-ai/faros-community-edition.git
 cd faros-community-edition || exit
-./start.sh --run-cli
-
+./start.sh --run-cli "$@"

--- a/start.sh
+++ b/start.sh
@@ -37,7 +37,7 @@ function parseFlags() {
 main() {
   parseFlags "$@"
   EMAIL_FILE=".faros-email"
-  if [[ ! -z "$email_override" ]]; then
+  if [[ -n "$email_override" ]]; then
       EMAIL=$email_override
       echo "$email_override" > $EMAIL_FILE
   else

--- a/start.sh
+++ b/start.sh
@@ -24,6 +24,9 @@ function parseFlags() {
             --run-cli)
                 run_cli=1
                 shift 1 ;;
+            --email)
+                email_override=$2
+                shift 2 ;;
             *)
                 echo "Unrecognized arg: $1"
                 shift ;;
@@ -33,15 +36,19 @@ function parseFlags() {
 
 main() {
   parseFlags "$@"
-
   EMAIL_FILE=".faros-email"
-  if [[ -f "$EMAIL_FILE" ]]; then
-      EMAIL=$(cat $EMAIL_FILE)
+  if [[ ! -z "$email_override" ]]; then
+      EMAIL=$email_override
+      echo "$email_override" > $EMAIL_FILE
   else
-      printf "Hello 👋 Welcome to Faros Community Edition! 🤗\n\n"
-      printf "Want to stay up to date with the latest community news? (we won't spam you)\n"
-      email_prompt
-      echo "$EMAIL" > $EMAIL_FILE
+      if [[ -f "$EMAIL_FILE" ]]; then
+          EMAIL=$(cat $EMAIL_FILE)
+      else
+          printf "Hello 👋 Welcome to Faros Community Edition! 🤗\n\n"
+          printf "Want to stay up to date with the latest community news? (we won't spam you)\n"
+          email_prompt
+          echo "$EMAIL" > $EMAIL_FILE
+      fi
   fi
 
   export FAROS_EMAIL=$EMAIL


### PR DESCRIPTION
# Description
Adds support for email override in start script
The install script also passes all parameters to `start.sh`, so one can do: 
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/faros-ai/faros-community-edition/main/install.sh)" _ --email foo@bar.com`

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
