### PR TITLE
Trigger metabase db sync on data sync to populate filters

### DIFF
--- a/cli/src/airbyte/airbyte-client.ts
+++ b/cli/src/airbyte/airbyte-client.ts
@@ -1,6 +1,6 @@
 import retry from 'async-retry';
 import axios, {AxiosInstance} from 'axios';
-import { ceil } from 'lodash';
+import {ceil} from 'lodash';
 import ProgressBar from 'progress';
 import {VError} from 'verror';
 

--- a/cli/src/bitbucket/run.ts
+++ b/cli/src/bitbucket/run.ts
@@ -5,6 +5,7 @@ import VError from 'verror';
 
 import {Airbyte} from '../airbyte/airbyte-client';
 import {wrapApiError} from '../cli';
+import {Metabase} from '../metabase/metabase-client';
 import {
   display,
   Emoji,
@@ -224,6 +225,16 @@ export async function runBitbucket(cfg: BitbucketConfig): Promise<void> {
     cfg.cutoffDays || DEFAULT_CUTOFF_DAYS,
     repos?.length || 0
   );
+
+  try {
+    await Metabase.triggerSyncOnDefaultLocalCEInstance();
+  } catch (error) {
+    // main intent is to have filters immediately populated with values
+    // we do nothing on failure, basic functionalities are not impacted
+    // daily/hourly metabase db scans will eventually get us there
+    // assumes default login/password for now
+    // (CLI is invoked by `start.sh` for Faros essentials)
+  }
 }
 
 interface Workspace {

--- a/cli/src/github/run.ts
+++ b/cli/src/github/run.ts
@@ -4,6 +4,7 @@ import VError from 'verror';
 
 import {Airbyte} from '../airbyte/airbyte-client';
 import {wrapApiError} from '../cli';
+import {Metabase} from '../metabase/metabase-client';
 import {
   display,
   Emoji,
@@ -143,6 +144,16 @@ export async function runGithub(cfg: GithubConfig): Promise<void> {
     cfg.cutoffDays || DEFAULT_CUTOFF_DAYS,
     repos?.length || 0
   );
+
+  try {
+    await Metabase.triggerSyncOnDefaultLocalCEInstance();
+  } catch (error) {
+    // main intent is to have filters immediately populated with values
+    // we do nothing on failure, basic functionalities are not impacted
+    // daily/hourly metabase db scans will eventually get us there
+    // assumes default login/password for now
+    // (CLI is invoked by `start.sh` for Faros essentials)
+  }
 }
 
 async function promptForRepos(token: string): Promise<ReadonlyArray<string>> {

--- a/cli/src/gitlab/run.ts
+++ b/cli/src/gitlab/run.ts
@@ -4,6 +4,7 @@ import VError from 'verror';
 
 import {Airbyte} from '../airbyte/airbyte-client';
 import {wrapApiError} from '../cli';
+import {Metabase} from '../metabase/metabase-client';
 import {
   display,
   Emoji,
@@ -151,6 +152,16 @@ export async function runGitlab(cfg: GitLabConfig): Promise<void> {
     cfg.cutoffDays || DEFAULT_CUTOFF_DAYS,
     projects?.length || 0
   );
+
+  try {
+    await Metabase.triggerSyncOnDefaultLocalCEInstance();
+  } catch (error) {
+    // main intent is to have filters immediately populated with values
+    // we do nothing on failure, basic functionalities are not impacted
+    // daily/hourly metabase db scans will eventually get us there
+    // assumes default login/password for now
+    // (CLI is invoked by `start.sh` for Faros essentials)
+  }
 }
 
 async function promptForProjects(

--- a/cli/src/jira/run.ts
+++ b/cli/src/jira/run.ts
@@ -4,6 +4,7 @@ import VError from 'verror';
 
 import {Airbyte} from '../airbyte/airbyte-client';
 import {wrapApiError} from '../cli';
+import {Metabase} from '../metabase/metabase-client';
 import {
   display,
   Emoji,
@@ -170,6 +171,16 @@ export async function runJira(cfg: JiraConfig): Promise<void> {
     cfg.cutoffDays || DEFAULT_CUTOFF_DAYS,
     projects?.length || 0
   );
+
+  try {
+    await Metabase.triggerSyncOnDefaultLocalCEInstance();
+  } catch (error) {
+    // main intent is to have filters immediately populated with values
+    // we do nothing on failure, basic functionalities are not impacted
+    // daily/hourly metabase db scans will eventually get us there
+    // assumes default login/password for now
+    // (CLI is invoked by `start.sh` for Faros essentials)
+  }
 }
 
 async function promptForProjects(

--- a/cli/src/metabase/metabase-client.ts
+++ b/cli/src/metabase/metabase-client.ts
@@ -1,0 +1,65 @@
+import axios, {AxiosInstance} from 'axios';
+import {VError} from 'verror';
+
+export function wrapApiError(cause: unknown, msg: string): Error {
+  // Omit verbose axios error
+  const truncated = new VError((cause as Error).message);
+  return new VError(truncated, msg);
+}
+
+export interface MetabaseConfig {
+  readonly url: string;
+  readonly username: string;
+  readonly password: string;
+}
+
+export class Metabase {
+  constructor(private readonly api: AxiosInstance) {}
+
+  static async fromConfig(cfg: MetabaseConfig): Promise<Metabase> {
+    const token = await Metabase.sessionToken(cfg);
+    const api = axios.create({
+      baseURL: `${cfg.url}/api`,
+      headers: {
+        'X-Metabase-Session': token,
+      },
+    });
+    return new Metabase(api);
+  }
+
+  private static async sessionToken(cfg: MetabaseConfig): Promise<string> {
+    const {url, username, password} = cfg;
+    try {
+      const {data} = await axios.post(`${url}/api/session`, {
+        username,
+        password,
+      });
+      return data.id;
+    } catch (err) {
+      throw wrapApiError(err, 'failed to get session token');
+    }
+  }
+
+  async forceSync(): Promise<any> {
+    try {
+      // Objective is to get filter values populated
+      // Faros is always has DB id 2
+      // note that API call rescan_value was not sufficient
+      // hence the call to sync_schema instead
+      // https://www.metabase.com/docs/latest/api/database
+      const {data} = await this.api.post('database/2/sync_schema');
+      return data;
+    } catch (err) {
+      throw wrapApiError(err, 'unable to trigger rescan');
+    }
+  }
+
+  static async triggerSyncOnDefaultLocalCEInstance(): Promise<any> {
+    const metabase = await Metabase.fromConfig({
+      url: 'http://localhost:3000',
+      username: 'admin@admin.com',
+      password: 'admin',
+    });
+    metabase.forceSync();
+  }
+}

--- a/cli/src/metabase/metabase-client.ts
+++ b/cli/src/metabase/metabase-client.ts
@@ -53,13 +53,4 @@ export class Metabase {
       throw wrapApiError(err, 'unable to trigger rescan');
     }
   }
-
-  static async triggerSyncOnDefaultLocalCEInstance(): Promise<any> {
-    const metabase = await Metabase.fromConfig({
-      url: 'http://localhost:3000',
-      username: 'admin@admin.com',
-      password: 'admin',
-    });
-    metabase.forceSync();
-  }
 }

--- a/init/resources/metabase/dashboards/git.json
+++ b/init/resources/metabase/dashboards/git.json
@@ -1600,8 +1600,7 @@
       "name": "Repository",
       "slug": "repository",
       "id": "81276e50",
-      "type": "string/=",
-      "sectionId": "string"
+      "type": "category"
     }
   ],
   "layout": [
@@ -2200,6 +2199,16 @@
         }
       ],
       "visualization_settings": {}
+    }
+  ],
+  "fields": [
+    {
+      "field": {{ field "vcs_Repository.name" }},
+      "type": "type/Category"
+    },
+    {
+      "field": {{ field "tms_TaskBoard.name" }},
+      "type": "type/Category"
     }
   ],
   "path": "/Faros CE/Git",

--- a/start.sh
+++ b/start.sh
@@ -76,7 +76,12 @@ main() {
     docker pull farosai/faros-ce-cli:latest
     AIRBYTE_URL=$(grep "^WEBAPP_URL" .env| sed 's/^WEBAPP_URL=//')
     METABASE_PORT=$(grep "^METABASE_PORT" .env| sed 's/^METABASE_PORT=//')
-    docker run --network host -it farosai/faros-ce-cli pick-source --airbyte-url "$AIRBYTE_URL" --metabase-url "http://localhost:$METABASE_PORT"
+    METABASE_USER=$(grep "^METABASE_USER" .env| sed 's/^METABASE_USER=//')
+    METABASE_PASSWORD=$(grep "^METABASE_PASSWORD" .env| sed 's/^METABASE_PASSWORD=//')
+    docker run --network host -it farosai/faros-ce-cli pick-source --airbyte-url "$AIRBYTE_URL" \
+    --metabase-url "http://localhost:$METABASE_PORT" \
+    --metabase-username "$METABASE_USER" \
+    --metabase-password "$METABASE_PASSWORD"
   fi
 }
 


### PR DESCRIPTION
# Description

A Metabase db schema sync is triggered after each successful CLI sync. This ensures dashboard filters are populated immediately.

Note
* a `rescan_values` API call is NOT sufficient (unknown reason); testing showed we had to go with `sync_schema`
* it silently fails on purpose and assumes default metabase credentials; failures do not impact main functionalities, and metabase has daily schema syncs anyway

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
