### PR TITLE
Render fields must be on for Jira source

### DIFF
--- a/cli/src/jira/run.ts
+++ b/cli/src/jira/run.ts
@@ -154,6 +154,7 @@ export async function runJira(cfg: JiraConfig): Promise<void> {
         domain,
         projects,
         start_date: startDate.toISOString().replace(/\.\d+/, ''),
+        render_fields: true,
         enable_experimental_streams: true,
         expand_issue_changelog: true,
       },


### PR DESCRIPTION
# Description

Render fields must be set by the CLI for Jira source, otherwise Epics and a few other things cannot be written.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
