### PR TITLE
Only updates main airbyte sources on startup

### DIFF
--- a/init/resources/airbyte/workspace/airbyte_config/SOURCE_CONNECTION.yaml
+++ b/init/resources/airbyte/workspace/airbyte_config/SOURCE_CONNECTION.yaml
@@ -78,7 +78,7 @@
     reject_unauthorized: true
   tombstone: false
 - name: "Harness"
-  sourceDefinitionId: "d8d05baf-bbda-49b3-9489-542e77cbd820"
+  sourceDefinitionId: "6fe89830-d04d-401b-aad6-6552ffa5c4af"
   workspaceId: "b740a9b4-048b-4500-b41b-038e14a3f2d5"
   sourceId: "c78b0bb2-5fee-46f7-a043-63e498004776"
   configuration:
@@ -90,7 +90,7 @@
     deployment_timeout: 24
   tombstone: false
 - name: "Jenkins"
-  sourceDefinitionId: "4c4613d8-ffcd-4db8-a8f8-d325052aec11"
+  sourceDefinitionId: "d6f73702-d7a0-4e95-9758-b0fb1af0bfba"
   workspaceId: "b740a9b4-048b-4500-b41b-038e14a3f2d5"
   sourceId: "55b0325e-4bc7-49b4-b230-36c5a67df068"
   configuration:
@@ -119,7 +119,7 @@
     application_key: ""
   tombstone: false
 - name: "PagerDuty"
-  sourceDefinitionId: "aee89078-5c00-429e-90bf-cec0174dbb76"
+  sourceDefinitionId: "2817b3f0-04e4-4c7a-9f32-7a5e8a83db95"
   workspaceId: "b740a9b4-048b-4500-b41b-038e14a3f2d5"
   sourceId: "5ed7412c-72d3-46a9-bc40-0e362ad437c6"
   configuration:
@@ -147,7 +147,7 @@
     cutoff_days: 90
   tombstone: false
 - name: "VictorOps"
-  sourceDefinitionId: "8b3ac13b-f1b1-4644-bec2-e7b6be6d64c4"
+  sourceDefinitionId: "7e20ce3e-d820-4327-ad7a-88f3927fd97a"
   workspaceId: "b740a9b4-048b-4500-b41b-038e14a3f2d5"
   sourceId: "e1d032e0-3a8b-47dc-bac8-2786264b11f4"
   configuration:

--- a/init/resources/airbyte/workspace/airbyte_config/STANDARD_DESTINATION_DEFINITION.yaml
+++ b/init/resources/airbyte/workspace/airbyte_config/STANDARD_DESTINATION_DEFINITION.yaml
@@ -2,7 +2,7 @@
 - destinationDefinitionId: "6c6366b8-11f9-419a-8cdc-9209def71e1f"
   name: "Faros Destination"
   dockerRepository: "farosai/airbyte-faros-destination"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://docs.faros.ai"
   spec:
     documentationUrl: "https://docs.faros.ai"

--- a/init/resources/airbyte/workspace/airbyte_config/STANDARD_SOURCE_DEFINITION.yaml
+++ b/init/resources/airbyte/workspace/airbyte_config/STANDARD_SOURCE_DEFINITION.yaml
@@ -105,7 +105,7 @@
 - sourceDefinitionId: "1b22f335-f5bb-442d-a345-38b860baa41d"
   name: "OpsGenie"
   dockerRepository: "farosai/airbyte-opsgenie-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/opsgenie-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -139,7 +139,7 @@
 - sourceDefinitionId: "431b2890-39cb-4138-bc30-7dccdd0b94e0"
   name: "Buildkite"
   dockerRepository: "farosai/airbyte-buildkite-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/buildkite-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -185,7 +185,7 @@
 - sourceDefinitionId: "4b3cd0a4-4994-4616-af28-9871e28a8368"
   name: "Statuspage"
   dockerRepository: "farosai/airbyte-statuspage-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/statuspage-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -221,10 +221,10 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- sourceDefinitionId: "4c4613d8-ffcd-4db8-a8f8-d325052aec11"
+- sourceDefinitionId: "d6f73702-d7a0-4e95-9758-b0fb1af0bfba"
   name: "Jenkins"
   dockerRepository: "farosai/airbyte-jenkins-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/jenkins-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -277,7 +277,7 @@
 - sourceDefinitionId: "51d2be20-0bdc-4532-b5a2-98a2ef91b23e"
   name: "Bitbucket"
   dockerRepository: "farosai/airbyte-bitbucket-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/bitbucket-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -346,7 +346,7 @@
 - sourceDefinitionId: "5e6175e5-68e1-4c17-bff9-56103bbb0d80"
   name: "Gitlab"
   dockerRepository: "airbyte/source-gitlab"
-  dockerImageTag: "0.1.3"
+  dockerImageTag: "0.1.6"
   documentationUrl: "https://docs.airbyte.io/integrations/sources/gitlab"
   icon: "gitlab.svg"
   sourceType: "api"
@@ -402,7 +402,7 @@
 - sourceDefinitionId: "63aa5e31-9490-4730-b2d4-14e42a4eb899"
   name: "Phabricator"
   dockerRepository: "farosai/airbyte-phabricator-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/phabricator-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -466,7 +466,7 @@
 - sourceDefinitionId: "6727d77e-5c06-4c28-817a-c1cacc18e106"
   name: "CircleCI"
   dockerRepository: "farosai/airbyte-circleci-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/circleci-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -512,7 +512,7 @@
 - sourceDefinitionId: "68e63de2-bb83-4c7e-93fa-a8a9051e3993"
   name: "Jira"
   dockerRepository: "airbyte/source-jira"
-  dockerImageTag: "0.2.20"
+  dockerImageTag: "0.3.0"
   documentationUrl: "https://docs.airbyte.io/integrations/sources/jira"
   icon: "jira.svg"
   spec:
@@ -593,10 +593,10 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- sourceDefinitionId: "8b3ac13b-f1b1-4644-bec2-e7b6be6d64c4"
+- sourceDefinitionId: "7e20ce3e-d820-4327-ad7a-88f3927fd97a"
   name: "VictorOps"
   dockerRepository: "farosai/airbyte-victorops-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/victorops-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -644,10 +644,10 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- sourceDefinitionId: "aee89078-5c00-429e-90bf-cec0174dbb76"
+- sourceDefinitionId: "2817b3f0-04e4-4c7a-9f32-7a5e8a83db95"
   name: "PagerDuty"
   dockerRepository: "farosai/airbyte-pagerduty-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/pagerduty-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -697,10 +697,10 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- sourceDefinitionId: "d8d05baf-bbda-49b3-9489-542e77cbd820"
+- sourceDefinitionId: "6fe89830-d04d-401b-aad6-6552ffa5c4af"
   name: "Harness"
   dockerRepository: "farosai/airbyte-harness-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/harness-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -751,7 +751,7 @@
 - sourceDefinitionId: "dcb04367-398c-4af9-831c-aef0ce4f8f32"
   name: "Squadcast"
   dockerRepository: "farosai/airbyte-squadcast-source"
-  dockerImageTag: "0.2.9"
+  dockerImageTag: "0.4.23"
   documentationUrl: "https://github.com/faros-ai/airbyte-connectors/tree/main/sources/squadcast-source"
   spec:
     documentationUrl: "https://docs.faros.ai"
@@ -806,7 +806,7 @@
 - sourceDefinitionId: "ef69ef6e-aa7f-4af1-a01d-ef775033524e"
   name: "GitHub"
   dockerRepository: "airbyte/source-github"
-  dockerImageTag: "0.2.19"
+  dockerImageTag: "0.3.8"
   documentationUrl: "https://docs.airbyte.io/integrations/sources/github"
   icon: "github.svg"
   sourceType: "api"

--- a/init/src/airbyte/init.ts
+++ b/init/src/airbyte/init.ts
@@ -247,16 +247,23 @@ export class AirbyteInit {
     }
   }
 
+  /**
+   * we update the sources we use in the CLI
+   *
+   * we do NOT update the other sources at startup
+   * those will use the version specified in the airbyte config
+   * and the binaries will be downloaded when source config is saved
+   */
   async updateSelectSourceVersions(concurrency?: number): Promise<void> {
     const listResponse = await this.api.post('/source_definitions/list');
     const farosSourceDefs = (
       listResponse.data.sourceDefinitions as SourceDefinition[]
     ).filter(
       (sd) =>
-        sd.dockerRepository.startsWith('farosai/') ||
         sd.dockerRepository === 'airbyte/source-jira' ||
         sd.dockerRepository === 'airbyte/source-github' ||
-        sd.dockerRepository === 'airbyte/source-gitlab'
+        sd.dockerRepository === 'airbyte/source-gitlab' ||
+        sd.dockerRepository === 'farosai/airbyte-bitbucket-source'
     );
 
     const promises: Promise<void>[] = [];

--- a/init/test/unit-tests/airbyte/init.test.ts
+++ b/init/test/unit-tests/airbyte/init.test.ts
@@ -66,7 +66,7 @@ describe('airbyte', () => {
     });
   });
 
-  test('send identity and start event even if email, version and source are not set', async () => {
+  test('send identity and start event with no traits', async () => {
     const host = 'http://test.test.com';
 
     const bodies = [];
@@ -84,7 +84,12 @@ describe('airbyte', () => {
     delete process.env.FAROS_INIT_VERSION;
     delete process.env.FAROS_START_SOURCE;
     const segmentUser = AirbyteInit.makeSegmentUser();
-    expect(segmentUser).toStrictEqual({userId: expect.anything(), email, version: '', source: ''});
+    expect(segmentUser).toStrictEqual({
+      userId: expect.anything(),
+      email,
+      version: '',
+      source: '',
+    });
 
     await AirbyteInit.sendIdentityAndStartEvent(segmentUser, host);
     analyticsMock.done();


### PR DESCRIPTION
# Description
We update the sources we use in the CLI
We do NOT update the other sources at startup, those will use the version specified in the airbyte config, and the binaries will be downloaded when source config is saved.

Tradeoff is faster start, but we will need to regularly update versions for other connectors in our airbyte config.

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
