### PR TITLE
shutdown before start to avoid race conditions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       AIRBYTE_DESTINATION_HASURA_URL: ${AIRBYTE_DESTINATION_HASURA_URL?}
       AIRBYTE_FORCE_SETUP: ${FAROS_AIRBYTE_FORCE_SETUP:-false}
       AIRBYTE_URL: ${AIRBYTE_URL?}
-      FAROS_EMAIL: ${FAROS_EMAIL}
+      FAROS_EMAIL: ${FAROS_EMAIL:-}
       FAROS_INIT_VERSION: ${FAROS_INIT_VERSION:-}
       FAROS_START_SOURCE: ${FAROS_START_SOURCE:-}
       HASURA_URL: ${HASURA_URL?}
@@ -41,9 +41,9 @@ services:
       N8N_DB_NAME: ${N8N_DB_NAME?}
     healthcheck:
       test: ["CMD", "psql", "-d", "postgres://${FAROS_CONFIG_DB_USER?}:${FAROS_CONFIG_DB_PASSWORD?}@${FAROS_CONFIG_DB_HOST?}:${FAROS_CONFIG_DB_PORT?}/${N8N_DB_NAME?}", "-c", "SELECT 1"]
-      interval: 15s
-      timeout: 5s
-      start_period: 30s
+      interval: 5s
+      timeout: 2s
+      start_period: 10s
       retries: 5
   
   # Airbyte

--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,9 @@ function parseFlags() {
 }
 
 main() {
+    # For consistency when running start on running containers
+    docker compose down
+
     parseFlags "$@"
     EMAIL_FILE=".faros-email"
     if [[ -n "$email_override" ]]; then

--- a/start.sh
+++ b/start.sh
@@ -44,8 +44,12 @@ function parseFlags() {
 }
 
 main() {
-    # For consistency when running start on running containers
-    docker compose down
+    RUNNING=$(docker compose ps -q --status=running | wc -l)
+    if [ "$RUNNING" -gt 0 ]; then
+        printf "Faros CE is still running. \n"
+        printf "You can stop it with the stop.sh command. \n"
+        exit 1
+    fi
 
     parseFlags "$@"
     EMAIL_FILE=".faros-email"
@@ -89,7 +93,7 @@ main() {
 
     if ((run_cli)); then
         CONTAINER_EXIT_CODE=$(docker wait faros-community-edition-faros-init-1)
-        if [ "$CONTAINER_EXIT_CODE" != 0 ]; then
+        if [ "$CONTAINER_EXIT_CODE" -gt 0 ]; then
             printf "An error occured during the initialization of Faros CE.\n"
             printf "For troubleshooting help, you can bring this log on our Slack workspace:\n"
             printf "https://community.faros.ai/docs/slack \n"

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker compose down
+exit

--- a/stop.sh
+++ b/stop.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+# only services in the compose file will be stopped
 docker compose down
 exit


### PR DESCRIPTION
If Faros CE is running when one launches start, the script exits.
This ensure a consistent interaction between services on start (e.g. metabase container does not start until db is configured)

## Type of change
(Delete what does not apply)
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
