### PR TITLE
Fix max Faros destination version to 0.4.48

### DIFF
--- a/init/resources/airbyte/workspace/airbyte_config/STANDARD_DESTINATION_DEFINITION.yaml
+++ b/init/resources/airbyte/workspace/airbyte_config/STANDARD_DESTINATION_DEFINITION.yaml
@@ -2,7 +2,7 @@
 - destinationDefinitionId: "6c6366b8-11f9-419a-8cdc-9209def71e1f"
   name: "Faros Destination"
   dockerRepository: "farosai/airbyte-faros-destination"
-  dockerImageTag: "0.4.23"
+  dockerImageTag: "0.4.48"
   documentationUrl: "https://docs.faros.ai"
   spec:
     documentationUrl: "https://docs.faros.ai"

--- a/init/src/airbyte/init.ts
+++ b/init/src/airbyte/init.ts
@@ -217,7 +217,9 @@ export class AirbyteInit {
   }
 
   async setupFarosDestinationDefinition(): Promise<void> {
-    const version = await AirbyteInit.getLatestImageTag(FAROS_DEST_REPO);
+    // const version = await AirbyteInit.getLatestImageTag(FAROS_DEST_REPO);
+    // Temporary
+    const version = "0.4.48";
     const listResponse = await this.api.post('/destination_definitions/list');
     const farosDestDef = find(
       listResponse.data.destinationDefinitions as DestinationDefinition[],


### PR DESCRIPTION
# Description

Faros destination version is only updated up to 0.4.48, until we resolve

Works around #272 

## Type of change
- temporary workaround

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
