### PR TITLE
CLI Bitbucket --server-url option fix

### DIFF
--- a/cli/src/bitbucket/run.ts
+++ b/cli/src/bitbucket/run.ts
@@ -42,7 +42,7 @@ export function makeBitbucketCommand(): Command {
   const cmd = new Command()
     .name('bitbucket')
     .option(
-      '--api-url <api-url>',
+      '--server-url <server-url>',
       'API URL, defaults to https://api.bitbucket.org/2.0'
     )
     .option('--username <username>', 'Username')
@@ -81,7 +81,7 @@ export async function runBitbucket(cfg: BitbucketConfig): Promise<void> {
   const serverUrl =
     cfg.serverUrl ||
     (await runInput({
-      name: 'api_url',
+      name: 'server_url',
       message: 'Enter the API URL, defaults to https://api.bitbucket.org/2.0',
     })) ||
     DEFAULT_API_URL;


### PR DESCRIPTION
`--api-url` does not map to the underlying Bitbucket spec, which calls it serverUrl.
It was simpler to change the CLI option.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
