### PR TITLE
Support v45+ Metabase dashcard size opts

### DIFF
--- a/init/src/metabase/dashboards.ts
+++ b/init/src/metabase/dashboards.ts
@@ -186,8 +186,9 @@ export class Dashboards {
       layout.push({
         row: cardLayout.row,
         col: cardLayout.col,
-        sizeX: cardLayout.sizeX,
-        sizeY: cardLayout.sizeY,
+        // Support for v45+
+        sizeX: cardLayout.sizeX ?? cardLayout.size_x,
+        sizeY: cardLayout.sizeY ?? cardLayout.size_y,
         card_id: cardLayout.card_id,
         series,
         parameter_mappings: cardLayout.parameter_mappings,

--- a/init/src/metabase/metabase.ts
+++ b/init/src/metabase/metabase.ts
@@ -398,6 +398,9 @@ export class Metabase {
         ...card,
         // Accept cardId or card_id
         cardId: card.cardId ?? card.card_id,
+        // v45+ size options. For v44 and below Metabase ignores them
+        size_x: card.sizeX,
+        size_y: card.sizeY,
       });
       return data;
     } catch (err) {


### PR DESCRIPTION
# Description

This change allows us to support Metabase v45+ size opts for cards added to dashboards.

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [X] Have you checked to there aren't other open Pull Requests for the same update/change?
- [X] Have you lint your code locally before submission?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run tests with your changes locally?
