### PR TITLE
Change syntax for patches

### DIFF
--- a/kube/base/kustomization.yaml
+++ b/kube/base/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   # Faros
   - ./faros
 patches:
-  - ./airbyte/db.yaml
+  - path: ./airbyte/db.yaml
 configMapGenerator:
   - name: faros-config
     behavior: merge


### PR DESCRIPTION
# Description

The kustomization.yaml in kube/base has invalid syntax for patches which causes the following error when using kustomize >= 5.0.0:

> invalid Kustomization: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch

This is a small change to add the proper syntax for patches in a file.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

This works with kustomize >= 4.1.3 which is when `replacements` was added.

# Checklist
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
