### PR TITLE
Incremental sync for `workflow_runs` stream in GitHub source

### DIFF
--- a/init/resources/airbyte/workspace/airbyte_config/STANDARD_SYNC.yaml
+++ b/init/resources/airbyte/workspace/airbyte_config/STANDARD_SYNC.yaml
@@ -223,12 +223,16 @@
         name: "workflow_runs"
         supported_sync_modes:
         - "full_refresh"
-        default_cursor_field: []
+        - "incremental"
+        source_defined_cursor: true
+        default_cursor_field:
+        - "updated_at"
         source_defined_primary_key:
         - - "id"
-      sync_mode: "full_refresh"
-      cursor_field: []
-      destination_sync_mode: "overwrite"
+      sync_mode: "incremental"
+      cursor_field:
+      - "updated_at"
+      destination_sync_mode: "append_dedup"
       primary_key:
       - - "id"
     - stream:


### PR DESCRIPTION
# Description

Since the community GitHub source now supports incremental sync for `workflow_runs` stream we should do that by default.

## Type of change
- New feature (non-breaking change which adds functionality)

# Checklist
(Delete what does not apply)
- [x] Have you checked to there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
