### PR TITLE
FAI-8461 - Remove unnecessary dep and bump jira.js

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -12,7 +12,6 @@
         "@gitbeaker/node": "^35.7.0",
         "@octokit/core": "^4.0.5",
         "@types/node": "^16.11.7",
-        "analytics-node": "^6.0.0",
         "async-retry": "^1.3.3",
         "axios": "^1.6.0",
         "bitbucket": "^2.8.0",
@@ -22,7 +21,7 @@
         "flat-cache": "^3.0.4",
         "fs-extra": "^10.0.0",
         "handlebars": "^4.7.7",
-        "jira.js": "^2.15.12",
+        "jira.js": "^2.19.1",
         "lodash": "^4.17.21",
         "p-limit": "^3.1.0",
         "pino": "^7.6.4",
@@ -35,7 +34,6 @@
         "verror": "^1.10.0"
       },
       "devDependencies": {
-        "@types/analytics-node": "^3.1.7",
         "@types/async-retry": "^1.4.3",
         "@types/figlet": "^1.5.4",
         "@types/flat-cache": "^2.0.0",
@@ -1454,15 +1452,6 @@
         "@octokit/openapi-types": "^13.11.0"
       }
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-      "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1489,12 +1478,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@types/analytics-node": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.7.tgz",
-      "integrity": "sha512-qoBHCXqFqC22Up8dus8YIloZ2t1f8MJx9b3E08ZBK04yJ/ai8U2WuFUnaIBiD1okw4VtuNjqKn9mgLHnLxb5OQ==",
-      "dev": true
     },
     "node_modules/@types/async-retry": {
       "version": "1.4.3",
@@ -2015,32 +1998,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/analytics-node": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.0.0.tgz",
-      "integrity": "sha512-qhwB5Fl/ps7VTg1/RnD3qJohceSHUjzTBqNn3DCmQZu/AdgPbGPeNFYu2o3xIuIyq+xZElrv0Do0b/zuGxBL9g==",
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.21.4",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/analytics-node/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -2274,21 +2231,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -2568,14 +2517,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -2685,11 +2626,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2721,14 +2657,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cssom": {
@@ -3941,11 +3869,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -4019,14 +3942,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4741,24 +4656,15 @@
       }
     },
     "node_modules/jira.js": {
-      "version": "2.15.12",
-      "resolved": "https://registry.npmjs.org/jira.js/-/jira.js-2.15.12.tgz",
-      "integrity": "sha512-jzNI4xwY1LI3KMW42Jmo6acY6ZlUzsxg7MeRiHEjVNSmg9zYja0Lavc/vARBC7Hid0CD30Nyuh49jZn8TrvLRw==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/jira.js/-/jira.js-2.20.1.tgz",
+      "integrity": "sha512-ZFlFAVTEaw86OemQ8BVyVSV0YDZqMI6WVc08Th5GgqVEODW4gmhXLOxqSmCasRJMMVAtI1LrFlFFTf9GnFaUhg==",
       "dependencies": {
         "atlassian-jwt": "^2.0.2",
-        "axios": "^0.27.2",
+        "axios": "^1.5.1",
         "form-data": "^4.0.0",
         "oauth": "^0.10.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/jira.js/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/jira.js/node_modules/form-data": {
@@ -4775,14 +4681,9 @@
       }
     },
     "node_modules/jira.js/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -4996,11 +4897,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5067,16 +4963,6 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/merge-stream": {
@@ -5208,7 +5094,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5824,11 +5711,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
-    },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7973,15 +7855,6 @@
         "@octokit/openapi-types": "^13.11.0"
       }
     },
-    "@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-      "requires": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -8004,12 +7877,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true
-    },
-    "@types/analytics-node": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.7.tgz",
-      "integrity": "sha512-qoBHCXqFqC22Up8dus8YIloZ2t1f8MJx9b3E08ZBK04yJ/ai8U2WuFUnaIBiD1okw4VtuNjqKn9mgLHnLxb5OQ==",
       "dev": true
     },
     "@types/async-retry": {
@@ -8419,31 +8286,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "analytics-node": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.0.0.tgz",
-      "integrity": "sha512-qhwB5Fl/ps7VTg1/RnD3qJohceSHUjzTBqNn3DCmQZu/AdgPbGPeNFYu2o3xIuIyq+xZElrv0Do0b/zuGxBL9g==",
-      "requires": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.21.4",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
-      }
-    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -8618,9 +8460,9 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -8637,14 +8479,6 @@
             "mime-types": "^2.1.12"
           }
         }
-      }
-    },
-    "axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "requires": {
-        "is-retry-allowed": "^1.1.0"
       }
     },
     "babel-jest": {
@@ -8851,11 +8685,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -8945,11 +8774,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
       "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
     },
-    "component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8979,11 +8803,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cssom": {
       "version": "0.4.4",
@@ -9876,11 +9695,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -9933,11 +9747,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -10496,26 +10305,17 @@
       }
     },
     "jira.js": {
-      "version": "2.15.12",
-      "resolved": "https://registry.npmjs.org/jira.js/-/jira.js-2.15.12.tgz",
-      "integrity": "sha512-jzNI4xwY1LI3KMW42Jmo6acY6ZlUzsxg7MeRiHEjVNSmg9zYja0Lavc/vARBC7Hid0CD30Nyuh49jZn8TrvLRw==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/jira.js/-/jira.js-2.20.1.tgz",
+      "integrity": "sha512-ZFlFAVTEaw86OemQ8BVyVSV0YDZqMI6WVc08Th5GgqVEODW4gmhXLOxqSmCasRJMMVAtI1LrFlFFTf9GnFaUhg==",
       "requires": {
         "atlassian-jwt": "^2.0.2",
-        "axios": "^0.27.2",
+        "axios": "^1.6.0",
         "form-data": "^4.0.0",
         "oauth": "^0.10.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        },
         "form-data": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -10527,16 +10327,11 @@
           }
         },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
-    },
-    "join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
     },
     "joycon": {
       "version": "3.1.1",
@@ -10704,11 +10499,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10765,16 +10555,6 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
-      }
-    },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "merge-stream": {
@@ -10867,7 +10647,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11323,11 +11104,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
-    },
-    "remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -26,7 +26,6 @@
     "@gitbeaker/node": "^35.7.0",
     "@octokit/core": "^4.0.5",
     "@types/node": "^16.11.7",
-    "analytics-node": "^6.0.0",
     "async-retry": "^1.3.3",
     "axios": "^1.6.0",
     "bitbucket": "^2.8.0",
@@ -36,7 +35,7 @@
     "flat-cache": "^3.0.4",
     "fs-extra": "^10.0.0",
     "handlebars": "^4.7.7",
-    "jira.js": "^2.15.12",
+    "jira.js": "^2.19.1",
     "lodash": "^4.17.21",
     "p-limit": "^3.1.0",
     "pino": "^7.6.4",
@@ -49,7 +48,6 @@
     "verror": "^1.10.0"
   },
   "devDependencies": {
-    "@types/analytics-node": "^3.1.7",
     "@types/async-retry": "^1.4.3",
     "@types/figlet": "^1.5.4",
     "@types/flat-cache": "^2.0.0",
@@ -73,6 +71,9 @@
     "prettier": "2.5.1",
     "ts-jest": "^27.1.3",
     "typescript": "^4.5.5"
+  },
+  "overrides": {
+    "axios": "^1.6.0"
   },
   "prettier": {
     "bracketSpacing": false,


### PR DESCRIPTION
# Description

Removes analytics-node and its transitive dependencies from the CLI package and upgrades jira.js dependency to an Axios-1.x-compatible version.


