### PR TITLE
Switch destination hasura url config to 127.0.0.1 to avoid ipv6

### DIFF
--- a/.env
+++ b/.env
@@ -36,7 +36,8 @@ DATABASE_DB=airbyte
 DATABASE_URL=jdbc:postgresql://faros-db:5432/airbyte
 # Host must correspond to the service name running webapp
 AIRBYTE_URL=http://airbyte-webapp:80
-AIRBYTE_DESTINATION_HASURA_URL=http://localhost:8080
+# Switched to 127.0.0.1 instead of localhost avoid IPv6 resolution by Node
+AIRBYTE_DESTINATION_HASURA_URL=http://127.0.0.1:8080
 
 ############################## Hasura #########################################
 HASURA_DB_NAME=hasura

--- a/kube/base/faros/config/.env
+++ b/kube/base/faros/config/.env
@@ -36,7 +36,8 @@ DATABASE_DB=airbyte
 DATABASE_URL=jdbc:postgresql://faros-db:5432/airbyte
 # Host must correspond to the service name running webapp
 AIRBYTE_URL=http://airbyte-webapp:80
-AIRBYTE_DESTINATION_HASURA_URL=http://localhost:8080
+# Switched to 127.0.0.1 instead of localhost avoid IPv6 resolution by Node
+AIRBYTE_DESTINATION_HASURA_URL=http://127.0.0.1:8080
 
 ############################## Hasura #########################################
 HASURA_DB_NAME=hasura


### PR DESCRIPTION
# Description

It appears that Node 18, which we recently moved to, [favors IPv6 resolution](https://github.com/nodejs/node/issues/40537). Given that Airbyte spawns sources and destinations as containers that run outside the Faros CE compose, this causes issues when the destination tries to connect to hasura on `::1:8080` instead of `127.0.0.1:8080`. Not sure exactly why - more docker networking expertise needed.

So the current fix is just to switch from `localhost` to an explicit IPv4 `127.0.0.1` in the destination settings, which works.

I am not touching other localhosts in the environment variables, as this behavior appears to be specific to code running on Node in a container. I also check that the mock-data scripts are unaffected (they do not run in a container).

## Type of change
(Delete what does not apply)
- Bug fix (non-breaking change which fixes an issue)

# Checklist
(Delete what does not apply)
- [x] Have you checked that there aren't other open Pull Requests for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
