### PR TITLE
add sql script to add runAttempt column to cicd_Build table

### DIFF
--- a/canonical-schema/V012_alter_cicd_build.sql
+++ b/canonical-schema/V012_alter_cicd_build.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cicd_Build" ADD "runAttempt" integer;


### PR DESCRIPTION
# Description

Add new column `run_attempt` to `cicd_Build` . 

Related PR https://github.com/faros-ai/airbyte-connectors/pull/1416

Fixes # (issue)

## Type of change
- New feature (non-breaking change which adds functionality)


# Checklist
(Delete what does not apply)
- [x] Have you checked that there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
