### PR TITLE
[FAI-13520] - Add recorded_at field to vcs_UserToolUsage for Copilot

### DIFF
--- a/canonical-schema/V015__alter_vcs_UserToolUsage.sql
+++ b/canonical-schema/V015__alter_vcs_UserToolUsage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "vcs_UserToolUsage" ADD column "recordedAt" timestamptz;


### PR DESCRIPTION
# Description

Adds an additional timestamp field, `recorded_at` for tracking freshness of tool usage data.

## Type of change
- New feature (non-breaking change which adds functionality)


# Checklist
(Delete what does not apply)
- [x] Have you checked that there aren't other open Pull Requests for the same update/change?
- [x] Have you lint your code locally before submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?
